### PR TITLE
Fix iOS 11 photo library crash

### DIFF
--- a/motion/core/device/ios/camera.rb
+++ b/motion/core/device/ios/camera.rb
@@ -185,7 +185,6 @@ module BubbleWrap
           nice_key = k.gsub("UIImagePickerController", "").underscore.to_sym
           val = info[k]
           callback_info[nice_key] = val
-          info.delete k
         }
 
         if media_type = callback_info[:media_type]


### PR DESCRIPTION
This line cause error 'can't modify frozen/immutable hash (RuntimeError)' in iOS 11 photo library.
This line is not necessary so I just delete it.